### PR TITLE
feat: migrate UniCafe prototype to Expo with web support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.expo
+.expo-shared
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+package-lock.json
+*.expo
+.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
-# UniCafe
-this repo is for education only
+# UNICAFE App
+
+Aplicación Expo con TypeScript para la demostración de la experiencia UNICAFE en Android, iOS y Web.
+
+## Requisitos
+
+- Node.js LTS (18+ recomendado)
+- npm 9+ o pnpm/yarn si se prefiere (los comandos listados usan npm)
+
+## Instalación
+
+```bash
+npm install
+```
+
+## Comandos
+
+| Comando | Descripción |
+| --- | --- |
+| `npm run start` | Inicia el servidor de desarrollo (Metro) con menú interactivo de Expo. |
+| `npm run start:web` | Abre el proyecto directamente en el navegador con Expo Web. |
+| `npm run typecheck` | Ejecuta TypeScript en modo estricto sin emitir archivos. |
+
+## Estructura principal
+
+```
+app/
+  _layout.tsx              # Configuración del stack (expo-router)
+  (public)/                # Rutas públicas disponibles en web
+    index.tsx              # WelcomeScreen
+    login/
+      estudiante.tsx       # StudentLoginScreen
+      personal.tsx         # StaffLoginScreen
+    dashboard/
+      estudiante.tsx       # StudentDashboardScreen
+      personal.tsx         # StaffDashboardScreen
+components/
+  FooterLinks.tsx          # Footer con enlaces e íconos
+  PrimaryButton.tsx        # Botón reutilizable con variantes
+  TextField.tsx            # Campo de texto estilizado con validaciones
+constants/
+  theme.ts                 # Definición de colores, espaciamiento y radios
+```
+
+## Notas de desarrollo
+
+- La navegación se implementa con **expo-router**, lo cual habilita soporte de rutas web de forma nativa.
+- Las validaciones de autenticación son simuladas. Los `TODO` marcan dónde integrar servicios reales.
+- Todos los textos permanecen en español según los requerimientos originales.
+- Asegura ejecutar `npm run typecheck` para verificar que no existan errores de tipos antes de publicar cambios.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,32 @@
+{
+  "expo": {
+    "name": "UNICAFE",
+    "slug": "unicafe",
+    "scheme": "unicafe",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "userInterfaceStyle": "light",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#F7F7FB"
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/adaptive-icon.png",
+        "backgroundColor": "#FFFFFF"
+      }
+    },
+    "web": {
+      "bundler": "metro",
+      "output": "single"
+    }
+  }
+}

--- a/app/(public)/dashboard/estudiante.tsx
+++ b/app/(public)/dashboard/estudiante.tsx
@@ -1,0 +1,50 @@
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet, Text, View } from 'react-native';
+import { FooterLinks } from '../../../components/FooterLinks';
+import { theme } from '../../../constants/theme';
+
+export default function StudentDashboardScreen() {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.content}>
+          <Text style={styles.title}>📚 Dashboard Estudiante</Text>
+          <Text style={styles.description}>
+            Haz tu pedido, revisa tu historial y controla tu alimentación.
+          </Text>
+        </View>
+        <FooterLinks />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: theme.colors.bg
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: theme.spacing * 3,
+    justifyContent: 'space-between'
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: theme.spacing * 2
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: theme.colors.text,
+    textAlign: 'center'
+  },
+  description: {
+    fontSize: 16,
+    color: theme.colors.subtext,
+    textAlign: 'center',
+    lineHeight: 24
+  }
+});

--- a/app/(public)/dashboard/personal.tsx
+++ b/app/(public)/dashboard/personal.tsx
@@ -1,0 +1,50 @@
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet, Text, View } from 'react-native';
+import { FooterLinks } from '../../../components/FooterLinks';
+import { theme } from '../../../constants/theme';
+
+export default function StaffDashboardScreen() {
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.content}>
+          <Text style={styles.title}>🏫 Dashboard Personal</Text>
+          <Text style={styles.description}>
+            Gestión de pedidos, inventario y reportes.
+          </Text>
+        </View>
+        <FooterLinks />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: theme.colors.bg
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: theme.spacing * 3,
+    justifyContent: 'space-between'
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: theme.spacing * 2
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: theme.colors.text,
+    textAlign: 'center'
+  },
+  description: {
+    fontSize: 16,
+    color: theme.colors.subtext,
+    textAlign: 'center',
+    lineHeight: 24
+  }
+});

--- a/app/(public)/index.tsx
+++ b/app/(public)/index.tsx
@@ -1,0 +1,80 @@
+import { useRouter } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { StyleSheet, Text, View } from 'react-native';
+import { FooterLinks } from '../../components/FooterLinks';
+import { PrimaryButton } from '../../components/PrimaryButton';
+import { theme } from '../../constants/theme';
+
+export default function WelcomeScreen() {
+  const router = useRouter();
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <View style={styles.container}>
+        <View style={styles.content}>
+          <Text style={styles.title}>UNICAFE App</Text>
+          <Text style={styles.subtitle}>¡Bienvenido a Unicafe!</Text>
+          <Text style={styles.description}>
+            Pide desde tu celular y recoge en la cafetería, evita filas y controla tu alimentación.
+          </Text>
+          <View style={styles.buttonGroup}>
+            <PrimaryButton
+              onPress={() => router.push('/login/estudiante')}
+              accessibilityLabel="Ingresar como estudiante"
+            >
+              Soy Estudiante
+            </PrimaryButton>
+            <PrimaryButton
+              variant="primaryAlt"
+              onPress={() => router.push('/login/personal')}
+              accessibilityLabel="Ingresar como personal"
+            >
+              Soy Personal
+            </PrimaryButton>
+          </View>
+        </View>
+        <FooterLinks />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: theme.colors.bg
+  },
+  container: {
+    flex: 1,
+    paddingHorizontal: theme.spacing * 3,
+    justifyContent: 'space-between'
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: theme.spacing * 3
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '800',
+    color: theme.colors.text,
+    textAlign: 'center'
+  },
+  subtitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: theme.colors.text,
+    textAlign: 'center'
+  },
+  description: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: theme.colors.subtext,
+    textAlign: 'center'
+  },
+  buttonGroup: {
+    width: '100%',
+    gap: theme.spacing * 2
+  }
+});

--- a/app/(public)/login/estudiante.tsx
+++ b/app/(public)/login/estudiante.tsx
@@ -1,0 +1,120 @@
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import { Alert, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { FooterLinks } from '../../../components/FooterLinks';
+import { PrimaryButton } from '../../../components/PrimaryButton';
+import { TextField } from '../../../components/TextField';
+import { theme } from '../../../constants/theme';
+
+const institutionalEmailRegex = /.+@.+\.edu$/i;
+
+export default function StudentLoginScreen() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [errors, setErrors] = useState<{ email?: string; password?: string }>({});
+
+  const handleSubmit = () => {
+    const newErrors: { email?: string; password?: string } = {};
+    if (!email.trim()) {
+      newErrors.email = 'Ingresa tu correo institucional';
+    } else if (!institutionalEmailRegex.test(email.trim())) {
+      newErrors.email = 'Usa tu correo institucional (.edu)';
+    }
+
+    if (!password.trim()) {
+      newErrors.password = 'Ingresa tu contraseña';
+    }
+
+    setErrors(newErrors);
+
+    if (Object.keys(newErrors).length === 0) {
+      // TODO: Integrar autenticación real con API institucional.
+      router.replace('/dashboard/estudiante');
+    }
+  };
+
+  const handleForgotPassword = () => {
+    Alert.alert('Recuperar contraseña', 'Funcionalidad disponible próximamente.');
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.flex}
+      >
+        <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+          <View style={styles.card}>
+            <Text style={styles.title}>Acceso Estudiante</Text>
+            <TextField
+              label="Correo institucional"
+              placeholder="tu.usuario@universidad.edu"
+              keyboardType="email-address"
+              autoCapitalize="none"
+              autoComplete="email"
+              textContentType="emailAddress"
+              value={email}
+              onChangeText={setEmail}
+              error={errors.email}
+            />
+            <TextField
+              label="Contraseña"
+              placeholder="Contraseña"
+              secureTextEntry
+              value={password}
+              onChangeText={setPassword}
+              error={errors.password}
+            />
+            <PrimaryButton onPress={handleSubmit} accessibilityLabel="Entrar como estudiante">
+              Entrar
+            </PrimaryButton>
+            <Text style={styles.forgotPassword} onPress={handleForgotPassword} accessibilityRole="link">
+              ¿Olvidaste tu contraseña?
+            </Text>
+          </View>
+          <FooterLinks />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: theme.colors.bg
+  },
+  flex: {
+    flex: 1
+  },
+  scrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: theme.spacing * 3,
+    paddingVertical: theme.spacing * 4,
+    justifyContent: 'space-between'
+  },
+  card: {
+    backgroundColor: theme.colors.card,
+    borderRadius: theme.radius,
+    padding: theme.spacing * 3,
+    gap: theme.spacing * 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.05,
+    shadowRadius: 12,
+    elevation: 3
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: theme.colors.text,
+    textAlign: 'center'
+  },
+  forgotPassword: {
+    color: theme.colors.link,
+    fontWeight: '600',
+    textAlign: 'center'
+  }
+});

--- a/app/(public)/login/personal.tsx
+++ b/app/(public)/login/personal.tsx
@@ -1,0 +1,117 @@
+import { useRouter } from 'expo-router';
+import { useState } from 'react';
+import { Alert, KeyboardAvoidingView, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { FooterLinks } from '../../../components/FooterLinks';
+import { PrimaryButton } from '../../../components/PrimaryButton';
+import { TextField } from '../../../components/TextField';
+import { theme } from '../../../constants/theme';
+
+export default function StaffLoginScreen() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [errors, setErrors] = useState<{ username?: string; password?: string }>({});
+
+  const handleSubmit = () => {
+    const newErrors: { username?: string; password?: string } = {};
+    if (!username.trim()) {
+      newErrors.username = 'Ingresa tu correo o número';
+    }
+
+    if (!password.trim()) {
+      newErrors.password = 'Ingresa tu contraseña';
+    }
+
+    setErrors(newErrors);
+
+    if (Object.keys(newErrors).length === 0) {
+      // TODO: Integrar autenticación real para personal.
+      router.replace('/dashboard/personal');
+    }
+  };
+
+  const handleForgotPassword = () => {
+    Alert.alert('Recuperar contraseña', 'Funcionalidad disponible próximamente.');
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.flex}
+      >
+        <ScrollView contentContainerStyle={styles.scrollContent} keyboardShouldPersistTaps="handled">
+          <View style={styles.card}>
+            <Text style={styles.title}>Acceso Personal</Text>
+            <TextField
+              label="Correo o número"
+              placeholder="usuario@universidad.edu"
+              autoCapitalize="none"
+              value={username}
+              onChangeText={setUsername}
+              error={errors.username}
+            />
+            <TextField
+              label="Contraseña"
+              placeholder="Contraseña"
+              secureTextEntry
+              value={password}
+              onChangeText={setPassword}
+              error={errors.password}
+            />
+            <PrimaryButton
+              variant="primaryAlt"
+              onPress={handleSubmit}
+              accessibilityLabel="Entrar como personal"
+            >
+              Entrar
+            </PrimaryButton>
+            <Text style={styles.forgotPassword} onPress={handleForgotPassword} accessibilityRole="link">
+              ¿Olvidaste tu contraseña?
+            </Text>
+          </View>
+          <FooterLinks />
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: theme.colors.bg
+  },
+  flex: {
+    flex: 1
+  },
+  scrollContent: {
+    flexGrow: 1,
+    paddingHorizontal: theme.spacing * 3,
+    paddingVertical: theme.spacing * 4,
+    justifyContent: 'space-between'
+  },
+  card: {
+    backgroundColor: theme.colors.card,
+    borderRadius: theme.radius,
+    padding: theme.spacing * 3,
+    gap: theme.spacing * 2,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.05,
+    shadowRadius: 12,
+    elevation: 3
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '800',
+    color: theme.colors.text,
+    textAlign: 'center'
+  },
+  forgotPassword: {
+    color: theme.colors.link,
+    fontWeight: '600',
+    textAlign: 'center'
+  }
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,0 +1,38 @@
+import { Stack } from 'expo-router';
+import { useEffect } from 'react';
+import { Platform, StatusBar, StyleSheet, View } from 'react-native';
+import { theme } from '../constants/theme';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+
+export default function RootLayout() {
+  useEffect(() => {
+    if (Platform.OS === 'web') {
+      document.body.style.backgroundColor = theme.colors.bg;
+      document.body.style.margin = '0';
+    }
+  }, []);
+
+  return (
+    <GestureHandlerRootView style={styles.root}>
+      <View style={styles.container}>
+        <StatusBar barStyle="dark-content" />
+        <Stack
+          screenOptions={{
+            headerShown: false,
+            contentStyle: { backgroundColor: theme.colors.bg }
+          }}
+        />
+      </View>
+    </GestureHandlerRootView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1
+  },
+  container: {
+    flex: 1,
+    paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight ?? 0 : 0
+  }
+});

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,3 @@
+# Assets
+
+Coloca aquí los recursos gráficos (icono, splash) cuando estén disponibles.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      require.resolve('expo-router/babel'),
+      'react-native-reanimated/plugin'
+    ]
+  };
+};

--- a/components/FooterLinks.tsx
+++ b/components/FooterLinks.tsx
@@ -1,0 +1,68 @@
+import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Ionicons, MaterialCommunityIcons, MaterialIcons } from '@expo/vector-icons';
+import { theme } from '../constants/theme';
+
+type FooterLink = {
+  label: string;
+  icon: JSX.Element;
+  url: string;
+};
+
+const links: FooterLink[] = [
+  {
+    label: 'Términos',
+    icon: <Ionicons name="document-text-outline" size={16} color={theme.colors.link} />,
+    url: 'https://example.com/terminos'
+  },
+  {
+    label: 'Privacidad',
+    icon: <MaterialIcons name="privacy-tip" size={16} color={theme.colors.link} />,
+    url: 'https://example.com/privacidad'
+  },
+  {
+    label: 'Soporte',
+    icon: <MaterialCommunityIcons name="lifebuoy" size={16} color={theme.colors.link} />,
+    url: 'mailto:soporte@unicafe.edu'
+  }
+];
+
+export function FooterLinks() {
+  return (
+    <View style={styles.container}>
+      {links.map((link) => (
+        <Pressable
+          key={link.label}
+          accessibilityRole="link"
+          onPress={() => void Linking.openURL(link.url)}
+          style={({ pressed }) => [styles.link, pressed && styles.linkPressed]}
+        >
+          {link.icon}
+          <Text style={styles.linkText}> {link.label}</Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: theme.spacing * 2,
+    flexWrap: 'wrap',
+    paddingVertical: theme.spacing * 2
+  },
+  link: {
+    flexDirection: 'row',
+    alignItems: 'center'
+  },
+  linkPressed: {
+    opacity: 0.7
+  },
+  linkText: {
+    color: theme.colors.link,
+    fontSize: 14,
+    fontWeight: '600'
+  }
+});

--- a/components/PrimaryButton.tsx
+++ b/components/PrimaryButton.tsx
@@ -1,0 +1,60 @@
+import { PropsWithChildren } from 'react';
+import { Pressable, StyleSheet, Text } from 'react-native';
+import { theme } from '../constants/theme';
+
+type ButtonVariant = 'primary' | 'primaryAlt';
+
+type PrimaryButtonProps = PropsWithChildren<{
+  variant?: ButtonVariant;
+  onPress?: () => void;
+  accessibilityLabel?: string;
+  disabled?: boolean;
+}>;
+
+export function PrimaryButton({
+  children,
+  variant = 'primary',
+  onPress,
+  accessibilityLabel,
+  disabled
+}: PrimaryButtonProps) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.base,
+        { backgroundColor: theme.colors[variant] },
+        pressed && styles.pressed,
+        disabled && styles.disabled
+      ]}
+    >
+      <Text style={styles.text}>{children}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  base: {
+    paddingVertical: theme.spacing * 1.5,
+    paddingHorizontal: theme.spacing * 2,
+    borderRadius: theme.radius,
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    minHeight: 48
+  },
+  text: {
+    color: '#FFFFFF',
+    fontWeight: '700',
+    fontSize: 16
+  },
+  pressed: {
+    opacity: 0.85
+  },
+  disabled: {
+    opacity: 0.6
+  }
+});

--- a/components/TextField.tsx
+++ b/components/TextField.tsx
@@ -1,0 +1,57 @@
+import { forwardRef } from 'react';
+import { StyleSheet, Text, TextInput, TextInputProps, View } from 'react-native';
+import { theme } from '../constants/theme';
+
+type TextFieldProps = TextInputProps & {
+  label: string;
+  error?: string;
+};
+
+export const TextField = forwardRef<TextInput, TextFieldProps>(
+  ({ label, error, style, ...props }, ref) => {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.label}>{label}</Text>
+        <TextInput
+          ref={ref}
+          style={[styles.input, style, error && styles.inputError]}
+          placeholderTextColor={theme.colors.subtext}
+          {...props}
+        />
+        {error ? <Text style={styles.error}>{error}</Text> : null}
+      </View>
+    );
+  }
+);
+
+TextField.displayName = 'TextField';
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%'
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: theme.colors.text,
+    marginBottom: theme.spacing
+  },
+  input: {
+    backgroundColor: theme.colors.inputBg,
+    borderColor: theme.colors.inputBorder,
+    borderWidth: 1,
+    borderRadius: theme.radius,
+    paddingHorizontal: theme.spacing * 1.5,
+    paddingVertical: theme.spacing * 1.5,
+    fontSize: 16,
+    color: theme.colors.text
+  },
+  inputError: {
+    borderColor: theme.colors.danger
+  },
+  error: {
+    color: theme.colors.danger,
+    fontSize: 13,
+    marginTop: theme.spacing * 0.5
+  }
+});

--- a/constants/theme.ts
+++ b/constants/theme.ts
@@ -1,0 +1,18 @@
+export const theme = {
+  colors: {
+    bg: '#F7F7FB',
+    card: '#FFFFFF',
+    text: '#111827',
+    subtext: '#6B7280',
+    primary: '#2563EB',
+    primaryAlt: '#06B6D4',
+    inputBg: '#FFFFFF',
+    inputBorder: '#E5E7EB',
+    danger: '#DC2626',
+    link: '#2563EB'
+  },
+  spacing: 8,
+  radius: 14
+} as const;
+
+export type Theme = typeof theme;

--- a/expo-env.d.ts
+++ b/expo-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="expo-router/entry" />

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "unicafe",
+  "version": "1.0.0",
+  "private": true,
+  "main": "expo-router/entry",
+  "scripts": {
+    "start": "expo start",
+    "start:web": "expo start --web",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@expo/vector-icons": "^14.0.0",
+    "expo": "^50.0.0",
+    "expo-router": "^3.4.7",
+    "expo-status-bar": "^1.11.1",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-native": "0.73.6",
+    "react-native-gesture-handler": "^2.14.0",
+    "react-native-reanimated": "^3.6.2",
+    "react-native-safe-area-context": "^4.8.2"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.0",
+    "@types/react": "~18.2.79",
+    "@types/react-native": "0.73.3",
+    "typescript": "~5.3.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "moduleResolution": "node",
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "expo-env.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold an Expo Router project with TypeScript, shared theme, and Expo configuration
- implement welcome, login, and dashboard screens with reusable UI components and footer links
- document project usage and commands for web and mobile development

## Testing
- npm run typecheck *(not run: npm install blocked by registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e6045b7b0c83229d04fa42a7297c1c